### PR TITLE
add small note for spacing without padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,7 @@ Use `Border` instead:
 
 - https://ellie-app.com/7f8nvkjCrD6a1
 - https://github.com/mdgriffith/elm-ui/issues/158
+
+## "spacing" does not respect spacing to the outer edges
+
+Spacing is the distance between contained elements. You are looking for "padding" on the container (to specify how near to the borders of the container the contained elements can be). 


### PR DESCRIPTION
I recently saw a note on slack that "padding doesn't seems to work on line 142. i wanted to shift the text away from the edge, at least 30px".
Just remembered that I also had this weird moment in the beginning, where I forgot about all CSS words when working with elm-ui and totally had the same "hey, why is spacing not respecting the spacing to the border"?

Feel free to disapprove if you think this is too much of a newbie concern or if this place is not the right one to add it.